### PR TITLE
Check if content has been added to the newspaper

### DIFF
--- a/tracker-update-snapshots/index.js
+++ b/tracker-update-snapshots/index.js
@@ -146,7 +146,8 @@ function addTrackerDataToItem(item) {
     .then((trackerData) => {
       console.log("fetched tracker data for " + item.path)
       const newItem = Object.assign({}, item, {
-        trackerData: trackerData
+        trackerData: trackerData,
+        inNewspaper: trackerData.inNewspaper
       });
 
       saveItem(newItem);
@@ -181,7 +182,7 @@ function findContentToCleanUp(callback, content, startKey) {
 };
 
 exports.handler = function(event, context) {
-
+  
   findContentToCleanUp((err, content) => {
     content.forEach(deleteItem);
   });


### PR DESCRIPTION
A piece of content may be added to the newspaper after it has been published online. We now check if it has been added to the newspaper when we update data in the tracker database.
